### PR TITLE
Adding embedded sourcemaps

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -17,6 +17,7 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('path to css directory'),
                 param('kernel.project_dir'),
                 abstract_arg('path to binary'),
+                abstract_arg('embed sourcemap'),
             ])
 
         ->set('sass.command.build', SassBuildCommand::class)

--- a/src/DependencyInjection/SymfonycastsSassExtension.php
+++ b/src/DependencyInjection/SymfonycastsSassExtension.php
@@ -19,8 +19,12 @@ use Symfony\Component\DependencyInjection\Loader;
 
 class SymfonycastsSassExtension extends Extension implements ConfigurationInterface
 {
+    private bool $isDebug;
+
     public function load(array $configs, ContainerBuilder $container): void
     {
+        $this->isDebug = $container->getParameter('kernel.debug');
+
         $loader = new Loader\PhpFileLoader($container, new FileLocator(__DIR__.'/../../config'));
         $loader->load('services.php');
 
@@ -31,6 +35,7 @@ class SymfonycastsSassExtension extends Extension implements ConfigurationInterf
             ->replaceArgument(0, $config['root_sass'])
             ->replaceArgument(1, '%kernel.project_dir%/var/sass')
             ->replaceArgument(3, $config['binary'])
+            ->replaceArgument(4, $config['embed_sourcemap'])
         ;
 
         $container->findDefinition('sass.css_asset_compiler')
@@ -63,6 +68,10 @@ class SymfonycastsSassExtension extends Extension implements ConfigurationInterf
                 ->scalarNode('binary')
                     ->info('The Sass binary to use')
                     ->defaultNull()
+                    ->end()
+                ->scalarNode('embed_sourcemap')
+                    ->info('Whether to embed the sourcemap in the compiled CSS')
+                    ->defaultValue($this->isDebug)
                     ->end()
             ->end()
         ;

--- a/src/DependencyInjection/SymfonycastsSassExtension.php
+++ b/src/DependencyInjection/SymfonycastsSassExtension.php
@@ -70,7 +70,7 @@ class SymfonycastsSassExtension extends Extension implements ConfigurationInterf
                     ->defaultNull()
                     ->end()
                 ->scalarNode('embed_sourcemap')
-                    ->info('Whether to embed the sourcemap in the compiled CSS')
+                    ->info('Whether to embed the sourcemap in the compiled CSS. By default, enabled only when debug mode is on.')
                     ->defaultValue($this->isDebug)
                     ->end()
             ->end()

--- a/src/SassBuilder.php
+++ b/src/SassBuilder.php
@@ -24,7 +24,8 @@ class SassBuilder
         private readonly array $sassPaths,
         private readonly string $cssPath,
         private readonly string $projectRootDir,
-        private readonly ?string $binaryPath
+        private readonly ?string $binaryPath,
+        private readonly bool $embedSourcemap,
     ) {
     }
 
@@ -36,6 +37,10 @@ class SassBuilder
 
         if ($watch) {
             $args[] = '--watch';
+        }
+
+        if ($this->embedSourcemap) {
+            $args[] = '--embed-source-map';
         }
 
         $process = $binary->createProcess($args);

--- a/tests/SassBuilderTest.php
+++ b/tests/SassBuilderTest.php
@@ -27,6 +27,7 @@ class SassBuilderTest extends TestCase
             __DIR__.'/fixtures/assets',
             __DIR__.'/fixtures',
             null,
+            false
         );
 
         $process = $builder->runBuild(false);


### PR DESCRIPTION
Simple solution to #6 - sourcemaps are included in the final `.css` file in debug mode.