### PR TITLE
[Doc] Fix index.rst syntax

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -61,20 +61,21 @@ When you run ``sass:build``, that binary is used to compile Sass files into a ``
 Excluding Sass Files from AssetMapper
 -------------------------------------
 
-Because you have `.scss` files in your `assets/` directory, when you deploy, these
-source files will be copied into the `public/assets/` directory. To prevent that,
+Because you have ``.scss`` files in your ``assets/`` directory, when you deploy, these
+source files will be copied into the ``public/assets/`` directory. To prevent that,
 you can exclude them from asset mapper:
 
-```yaml
-# config/packages/asset_mapper.yaml
-framework:
-    asset_mapper:
-        paths:
-            - assets/
-        excluded_patterns:
-            - '*/assets/styles/_*.scss'
-            - '*/assets/styles/**/_*.scss'
-```
+.. code-block:: yaml
+
+    # config/packages/asset_mapper.yaml
+    framework:
+        asset_mapper:
+            paths:
+                - assets/
+            excluded_patterns:
+                - '*/assets/styles/_*.scss'
+                - '*/assets/styles/**/_*.scss'
+
 
 Note: be sure not to exclude your *main* SCSS file (e.g. ``assets/styles/app.scss``):
 this *is* used in AssetMapper and its contents are swapped for the final, built CSS.
@@ -107,7 +108,7 @@ When you deploy, run ``sass:build`` command before the ``asset-map:compile`` com
     $ php bin/console sass:build
     $ php bin/console asset-map:compile
 
-Limitation: url() Relative Paths
+Limitation: ``url()`` Relative Paths
 --------------------------------
 
 When using ``url()`` inside a Sass file, currently, the path must be relative to the *root* ``.scss`` file. For example, suppose the root ``.scss`` file is:


### PR DESCRIPTION
Two minor bugs fixed on this page: https://github.com/SymfonyCasts/sass-bundle/blob/main/doc/index.rst 
* missing double ticks around "code" terms
* code block yaml

| symfony.com | github.com |
| - | - |
| ![Capture d’écran 2023-09-17 à 00 41 36](https://github.com/SymfonyCasts/sass-bundle/assets/1359581/0f1ca009-aa22-4c1a-86b1-f68cb20e539b) | ![Capture d’écran 2023-09-17 à 00 40 43](https://github.com/SymfonyCasts/sass-bundle/assets/1359581/c4222a55-f78a-4002-a421-f0f44af57a64) |
