### PR TITLE
Set a default value for $isDebug in SymfonycastsSassExtension

### DIFF
--- a/src/DependencyInjection/SymfonycastsSassExtension.php
+++ b/src/DependencyInjection/SymfonycastsSassExtension.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\Loader;
 
 class SymfonycastsSassExtension extends Extension implements ConfigurationInterface
 {
-    private bool $isDebug;
+    private bool $isDebug = false;
 
     public function load(array $configs, ContainerBuilder $container): void
     {

--- a/src/DependencyInjection/SymfonycastsSassExtension.php
+++ b/src/DependencyInjection/SymfonycastsSassExtension.php
@@ -19,12 +19,8 @@ use Symfony\Component\DependencyInjection\Loader;
 
 class SymfonycastsSassExtension extends Extension implements ConfigurationInterface
 {
-    private bool $isDebug = false;
-
     public function load(array $configs, ContainerBuilder $container): void
     {
-        $this->isDebug = $container->getParameter('kernel.debug');
-
         $loader = new Loader\PhpFileLoader($container, new FileLocator(__DIR__.'/../../config'));
         $loader->load('services.php');
 
@@ -71,7 +67,7 @@ class SymfonycastsSassExtension extends Extension implements ConfigurationInterf
                     ->end()
                 ->scalarNode('embed_sourcemap')
                     ->info('Whether to embed the sourcemap in the compiled CSS. By default, enabled only when debug mode is on.')
-                    ->defaultValue($this->isDebug)
+                    ->defaultValue('%kernel.debug%')
                     ->end()
             ->end()
         ;


### PR DESCRIPTION
At the moment when you run `php bin/console config:dump symfonycasts_sass` it throws an exception.

```
In SymfonycastsSassExtension.php line 74:

Typed property Symfonycasts\SassBundle\DependencyInjection\SymfonycastsSassExtension::$isDebug must not be accessed before initialization
```

Setting a default value fixes this.