### PR TITLE
Constrain AssetMapper 6.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "symfony/asset-mapper": "^6.3",
+        "symfony/asset-mapper": "^6.3, <6.4",
         "symfony/console": "^5.4|^6.3",
         "symfony/http-client": "^5.4|^6.3",
         "symfony/process": "^5.4|^6.3"


### PR DESCRIPTION
In order to fix PhpStan error in #23 

```
Run vendor/bin/phpstan analyse
Note: Using configuration file /home/runner/work/sass-bundle/sass-bundle/phpstan.neon.dist.
 0/7 [░░░░░░░░░░░░░░░░░░░░░░░░░░░░]   0%
 7/7 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] [10](https://github.com/SymfonyCasts/sass-bundle/actions/runs/6655476098/job/18179258827?pr=23#step:5:11)0%

Error: Call to an undefined method Symfony\Component\AssetMapper\Path\PublicAssetsPathResolverInterface::getPublicFilesystemPath().
 ------ -------------------------------------------------------------------------------------------------- 
  Line   AssetMapper/SassPublicPathAssetPathResolver.php                                                   
 ------ -------------------------------------------------------------------------------------------------- 
  33     Call to an undefined method                                                                       
         Symfony\Component\AssetMapper\Path\PublicAssetsPathResolverInterface::getPublicFilesystemPath().  
 ------ -------------------------------------------------------------------------------------------------- 


Error:  [ERROR] Found 1 error                                                          

Error: Process completed with exit code 1.
```

Seems `getPublicFilesystemPath()` is gone from the `Symfony\Component\AssetMapper\Path\PublicAssetsPathResolverInterface` in 6.4. I suppose we should release this fix, and then drop `getPublicFilesystemPath()` from ours `SassPublicPathAssetPathResolver()` as well and release it again?

Any thoughts?