### PR TITLE
Better exception if the built file is not present

### DIFF
--- a/src/AssetMapper/SassCssCompiler.php
+++ b/src/AssetMapper/SassCssCompiler.php
@@ -40,7 +40,7 @@ class SassCssCompiler implements AssetCompilerInterface
 
         $asset->addFileDependency($cssFile);
 
-        if (($content = file_get_contents($cssFile)) === false) {
+        if (!is_file($cssFile) || ($content = file_get_contents($cssFile)) === false) {
             throw new \RuntimeException('The file '.$cssFile.' doesn\'t exist, run php bin/console sass:build');
         }
 


### PR DESCRIPTION
Checking for `file_get_contents()` to be false doesn't do it - that triggers an error. This works much better.