### PR TITLE
Deprecated getPublicFilesystemPath in SassPublicPathAssetPathResolver, fixes phpstan suite

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "php": ">=8.1",
         "symfony/asset-mapper": "^6.3",
         "symfony/console": "^5.4|^6.3",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/http-client": "^5.4|^6.3",
         "symfony/process": "^5.4|^6.3"
     },

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,3 +8,7 @@ parameters:
             message: "#^Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeParentInterface\\:\\:defaultValue\\(\\)\\.$#"
             count: 1
             path: src/DependencyInjection/SymfonycastsSassExtension.php
+        -
+            message: "#^Call to an undefined method Symfony\\\\Component\\\\AssetMapper\\\\Path\\\\PublicAssetsPathResolverInterface\\:\\:getPublicFilesystemPath\\(\\)\\.$#"
+            count: 1
+            path: src/AssetMapper/SassPublicPathAssetPathResolver.php

--- a/src/AssetMapper/SassPublicPathAssetPathResolver.php
+++ b/src/AssetMapper/SassPublicPathAssetPathResolver.php
@@ -30,6 +30,8 @@ class SassPublicPathAssetPathResolver implements PublicAssetsPathResolverInterfa
 
     public function getPublicFilesystemPath(): string
     {
+        trigger_deprecation('symfony/asset-mapper', '6.4', 'Calling "%s()" is deprecated, use "resolvePublicPath()" instead.', __METHOD__);
+
         $path = $this->decorator->getPublicFilesystemPath();
 
         if (str_contains($path, '.scss')) {


### PR DESCRIPTION
[The PHPStan error](https://github.com/SymfonyCasts/sass-bundle/actions/runs/6851991886/job/18629495364?pr=30) is caused because of the [removal](https://github.com/symfony/symfony/commit/48a2d689e6e91c943d931d30e90555726ac6f7c7#diff-8493cb0e782a4fe3c754664c4fa0101a3fcf8bd8bdc504b48d614bf3849f1b3cL24) of `getPublicFilesystemPath` in `PublicAssetsPathResolverInterface`.

~~Removing the method here also fixes the phpstan error.~~

~~Guess since this bundle is still in it's `0.x` major version we could just follow the `asset-mapper` component? Or do we need to deprecate the method and add an ignore in the phpstan config and remove it in the `1.x` version?~~

edit: Deprecated the function and added an ignore to phpstan