### PR TITLE
Added config validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "symfony/process": "^5.4|^6.3"
     },
     "require-dev": {
+        "matthiasnoback/symfony-config-test": "^5.0",
         "symfony/filesystem": "^6.3",
         "symfony/framework-bundle": "^6.3",
         "symfony/phpunit-bridge": "^6.3",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/filesystem": "^6.3",
         "symfony/framework-bundle": "^6.3",
         "symfony/phpunit-bridge": "^6.3",
-        "phpstan/phpstan": "1.11.x-dev"
+        "phpstan/phpstan-symfony": "^1.4"
     },
     "minimum-stability": "dev",
     "autoload": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,6 +2,6 @@ includes:
         - vendor/phpstan/phpstan-symfony/extension.neon
 
 parameters:
-    level: 4
+    level: 5
     paths:
         - src

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,10 +1,7 @@
+includes:
+        - vendor/phpstan/phpstan-symfony/extension.neon
+
 parameters:
     level: 4
     paths:
         - src
-
-    ignoreErrors:
-        -
-            message: "#^Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeParentInterface\\:\\:defaultValue\\(\\)\\.$#"
-            count: 1
-            path: src/DependencyInjection/SymfonycastsSassExtension.php

--- a/src/DependencyInjection/SymfonycastsSassExtension.php
+++ b/src/DependencyInjection/SymfonycastsSassExtension.php
@@ -73,7 +73,7 @@ class SymfonycastsSassExtension extends Extension implements ConfigurationInterf
 
                             return \count($filenames) !== \count($paths);
                         })
-                        ->thenInvalid('The root sass-paths need to end with unique filenames.')
+                        ->thenInvalid('The "root_sass" paths need to end with unique filenames.')
                         ->end()
                     ->defaultValue(['%kernel.project_dir%/assets/styles/app.scss'])
                 ->end()

--- a/src/DependencyInjection/SymfonycastsSassExtension.php
+++ b/src/DependencyInjection/SymfonycastsSassExtension.php
@@ -17,6 +17,9 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 
+use function basename;
+use function in_array;
+
 class SymfonycastsSassExtension extends Extension implements ConfigurationInterface
 {
     public function load(array $configs, ContainerBuilder $container): void
@@ -58,6 +61,22 @@ class SymfonycastsSassExtension extends Extension implements ConfigurationInterf
                     ->info('Path to your Sass root file')
                     ->cannotBeEmpty()
                     ->scalarPrototype()
+                        ->end()
+                    ->validate()
+                        ->ifTrue(static function (array $paths): bool {
+                            if (count($paths) === 1) {
+                                return false;
+                            }
+
+                            $filenames = [];
+                            foreach ($paths as $path) {
+                                $filename = basename($path, '.scss');
+                                $filenames[$filename] = $filename;
+                            }
+
+                            return count($filenames) !== count($paths);
+                        })
+                        ->thenInvalid('The root sass-paths need to end with unique filenames.')
                         ->end()
                     ->defaultValue(['%kernel.project_dir%/assets/styles/app.scss'])
                 ->end()

--- a/src/DependencyInjection/SymfonycastsSassExtension.php
+++ b/src/DependencyInjection/SymfonycastsSassExtension.php
@@ -17,9 +17,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 
-use function basename;
-use function in_array;
-
 class SymfonycastsSassExtension extends Extension implements ConfigurationInterface
 {
     public function load(array $configs, ContainerBuilder $container): void
@@ -64,7 +61,7 @@ class SymfonycastsSassExtension extends Extension implements ConfigurationInterf
                         ->end()
                     ->validate()
                         ->ifTrue(static function (array $paths): bool {
-                            if (count($paths) === 1) {
+                            if (1 === \count($paths)) {
                                 return false;
                             }
 
@@ -74,7 +71,7 @@ class SymfonycastsSassExtension extends Extension implements ConfigurationInterf
                                 $filenames[$filename] = $filename;
                             }
 
-                            return count($filenames) !== count($paths);
+                            return \count($filenames) !== \count($paths);
                         })
                         ->thenInvalid('The root sass-paths need to end with unique filenames.')
                         ->end()

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfonycasts\SassBundle\Tests;
+
+use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
+use PHPUnit\Framework\TestCase;
+use Symfonycasts\SassBundle\DependencyInjection\SymfonycastsSassExtension;
+
+final class ConfigurationTest extends TestCase
+{
+    use ConfigurationTestCaseTrait;
+
+    protected function getConfiguration(): SymfonycastsSassExtension
+    {
+        return new SymfonycastsSassExtension();
+    }
+
+    public function testSingleSassRootPath(): void
+    {
+        $this->assertConfigurationIsValid([
+            'symfonycasts_sass' => [
+                'root_sass' => [
+                    '%kernel.project_dir%/assets/scss/app.scss'
+                ]
+            ]
+        ]);
+    }
+
+    public function testMultipleSassRootPaths(): void
+    {
+        $this->assertConfigurationIsValid([
+            'symfonycasts_sass' => [
+                'root_sass' => [
+                    '%kernel.project_dir%/assets/scss/app.scss',
+                    '%kernel.project_dir%/assets/admin/scss/admin.scss'
+                ]
+            ]
+        ]);
+    }
+
+    public function testMultipleSassRootPathsWithSameFilename(): void
+    {
+        $this->assertConfigurationIsInvalid([
+            'symfonycasts_sass' => [
+                'root_sass' => [
+                    '%kernel.project_dir%/assets/scss/app.scss',
+                    '%kernel.project_dir%/assets/admin/scss/app.scss'
+                ]
+            ]
+        ],
+        'Invalid configuration for path "symfonycasts_sass.root_sass": The root sass-paths need to end with unique filenames.');
+    }
+}

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the SymfonyCasts SassBundle package.
+ * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfonycasts\SassBundle\Tests;
 
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
@@ -22,9 +29,9 @@ final class ConfigurationTest extends TestCase
         $this->assertConfigurationIsValid([
             'symfonycasts_sass' => [
                 'root_sass' => [
-                    '%kernel.project_dir%/assets/scss/app.scss'
-                ]
-            ]
+                    '%kernel.project_dir%/assets/scss/app.scss',
+                ],
+            ],
         ]);
     }
 
@@ -34,9 +41,9 @@ final class ConfigurationTest extends TestCase
             'symfonycasts_sass' => [
                 'root_sass' => [
                     '%kernel.project_dir%/assets/scss/app.scss',
-                    '%kernel.project_dir%/assets/admin/scss/admin.scss'
-                ]
-            ]
+                    '%kernel.project_dir%/assets/admin/scss/admin.scss',
+                ],
+            ],
         ]);
     }
 
@@ -46,10 +53,10 @@ final class ConfigurationTest extends TestCase
             'symfonycasts_sass' => [
                 'root_sass' => [
                     '%kernel.project_dir%/assets/scss/app.scss',
-                    '%kernel.project_dir%/assets/admin/scss/app.scss'
-                ]
-            ]
+                    '%kernel.project_dir%/assets/admin/scss/app.scss',
+                ],
+            ],
         ],
-        'Invalid configuration for path "symfonycasts_sass.root_sass": The root sass-paths need to end with unique filenames.');
+            'Invalid configuration for path "symfonycasts_sass.root_sass": The root sass-paths need to end with unique filenames.');
     }
 }

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -57,6 +57,6 @@ final class ConfigurationTest extends TestCase
                 ],
             ],
         ],
-            'Invalid configuration for path "symfonycasts_sass.root_sass": The root sass-paths need to end with unique filenames.');
+            'Invalid configuration for path "symfonycasts_sass.root_sass": The "root_sass" paths need to end with unique filenames.');
     }
 }


### PR DESCRIPTION
Currently with the following config:

```yaml
symfonycasts_sass:
    root_sass:
        - '%kernel.project_dir%/assets/admin/scss/app.scss'
        - '%kernel.project_dir%/assets/website/scss/app.scss'
```

Running the `sass:build` command would result all configured paths to be build in 1 file; `var/sass/app.output.css`, as all `root_sass` paths with the same filename will be stored under the same css filename, thus overwriting the file.

This PR throws an exception when configuring the sass-paths. (follow-up on #30)