### PR TITLE
Update section Source Sass file in the documentation

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -87,8 +87,10 @@ you can exclude them from asset mapper:
                 - '*/assets/styles/_*.scss'
                 - '*/assets/styles/**/_*.scss'
 
-Note: be sure not to exclude your *main* SCSS file (e.g. ``assets/styles/app.scss``):
-this *is* used in AssetMapper and its contents are swapped for the final, built CSS.
+.. note::
+
+    Be sure not to exclude your *main* SCSS file (e.g. ``assets/styles/app.scss``):
+    this *is* used in AssetMapper and its contents are swapped for the final, built CSS.
 
 Using Bootstrap Sass
 --------------------
@@ -166,13 +168,13 @@ The main option is ``root_sass`` option, which defaults to ``assets/styles/app.s
 
 .. note::
 
-The option ``root_sass`` also supports array of paths that represents different source Sass files
+    The ``root_sass`` option also supports an array of paths that represents different source Sass files:
 
-.. code-block:: yaml
+    .. code-block:: yaml
 
-    symfony_cast:
-        root_sass:
-            - '%kernel.project_dir%/assets/scss/app.scss'
+        symfony_cast:
+            root_sass:
+                - '%kernel.project_dir%/assets/scss/app.scss'
 
 Sass CLI Options
 ~~~~~~~~~~~~~~~~

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -164,6 +164,15 @@ The main option is ``root_sass`` option, which defaults to ``assets/styles/app.s
     symfonycasts_sass:
         root_sass:  'assets/styles/app.scss'
 
+.. note::
+
+The option ``root_sass`` also supports array of paths that represents different source Sass files
+
+.. code-block:: yaml
+
+    symfony_cast:
+        root_sass:
+            - '%kernel.project_dir%/assets/scss/app.scss'
 
 Sass CLI Options
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
the current yaml snippet in the section [Source Sass file](https://github.com/SymfonyCasts/sass-bundle/blob/main/doc/index.rst#source-sass-file) throws the error in the screenshot

<img width="1080" alt="image" src="https://github.com/SymfonyCasts/sass-bundle/assets/19323431/9f8f2ae8-b9b0-4c96-8b6e-978221c1c508">

the correct yaml snippet is:
```
symfonycasts_sass:
  root_sass:
   - 'assets/styles/app.scss'
```