### PR TITLE
Allow custom root_sass to be relative paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
         "php": ">=8.1",
         "symfony/asset-mapper": "^6.3|^7.0",
         "symfony/console": "^5.4|^6.3|^7.0",
+        "symfony/filesystem": "^5.4|^6.3|^7.0",
         "symfony/http-client": "^5.4|^6.3|^7.0",
         "symfony/process": "^5.4|^6.3|^7.0"
     },
     "require-dev": {
         "matthiasnoback/symfony-config-test": "^5.0",
-        "symfony/filesystem": "^6.3|^7.0",
         "symfony/framework-bundle": "^6.3|^7.0",
         "symfony/phpunit-bridge": "^6.3|^7.0",
         "phpstan/phpstan-symfony": "^1.4"

--- a/config/services.php
+++ b/config/services.php
@@ -35,6 +35,7 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 abstract_arg('path to scss files'),
                 abstract_arg('path to css output directory'),
+                param('kernel.project_dir'),
                 service('sass.builder'),
             ])
 

--- a/src/AssetMapper/SassCssCompiler.php
+++ b/src/AssetMapper/SassCssCompiler.php
@@ -12,6 +12,7 @@ namespace Symfonycasts\SassBundle\AssetMapper;
 use Symfony\Component\AssetMapper\AssetMapperInterface;
 use Symfony\Component\AssetMapper\Compiler\AssetCompilerInterface;
 use Symfony\Component\AssetMapper\MappedAsset;
+use Symfony\Component\Filesystem\Path;
 use Symfonycasts\SassBundle\SassBuilder;
 
 class SassCssCompiler implements AssetCompilerInterface
@@ -19,6 +20,7 @@ class SassCssCompiler implements AssetCompilerInterface
     public function __construct(
         private array $scssPaths,
         private string $cssPathDirectory,
+        private string $projectDir,
         private readonly SassBuilder $sassBuilder
     ) {
     }
@@ -26,7 +28,9 @@ class SassCssCompiler implements AssetCompilerInterface
     public function supports(MappedAsset $asset): bool
     {
         foreach ($this->scssPaths as $path) {
-            if (realpath($asset->sourcePath) === realpath($path)) {
+            $absolutePath = Path::isAbsolute($path) ? $path : Path::makeAbsolute($path, $this->projectDir);
+
+            if (realpath($asset->sourcePath) === realpath($absolutePath)) {
                 return true;
             }
         }

--- a/tests/AssetMapper/SassCssCompilerTest.php
+++ b/tests/AssetMapper/SassCssCompilerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the SymfonyCasts SassBundle package.
+ * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfonycasts\SassBundle\Tests\AssetMapper;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\AssetMapper\MappedAsset;
+use Symfonycasts\SassBundle\AssetMapper\SassCssCompiler;
+use Symfonycasts\SassBundle\SassBuilder;
+
+class SassCssCompilerTest extends TestCase
+{
+    public function testSupports()
+    {
+        $builder = $this->createMock(SassBuilder::class);
+
+        $asset = new MappedAsset('assets/app.scss', __DIR__.'/../fixtures/assets/app.scss');
+
+        $compilerAbsolutePath = new SassCssCompiler(
+            [__DIR__.'/../fixtures/assets/app.scss'],
+            __DIR__.'/../fixtures/var/sass',
+            __DIR__.'/../fixtures',
+            $builder
+        );
+
+        $this->assertTrue($compilerAbsolutePath->supports($asset), 'Supports absolute paths');
+
+        $compilerRelativePath = new SassCssCompiler(
+            ['assets/app.scss'],
+            __DIR__.'/../fixtures/var/sass',
+            __DIR__.'/../fixtures',
+            $builder
+        );
+
+        $this->assertTrue($compilerRelativePath->supports($asset), 'Supportes relative paths');
+    }
+}


### PR DESCRIPTION
I added a failing case and a fix following https://github.com/SymfonyCasts/sass-bundle/issues/43#issuecomment-1953943241.

**This fix should not works on windows.** I though about requiring symfony/filesystem for its `isAbsolutePath` but I don't want add another dependency if windows support was never in scope of this bundle.