### PR TITLE
[dx] keep tooling in one place

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
     "require-dev": {
         "matthiasnoback/symfony-config-test": "^5.0",
         "symfony/framework-bundle": "^6.3|^7.0",
-        "symfony/phpunit-bridge": "^6.3|^7.0",
-        "phpstan/phpstan-symfony": "^1.4"
+        "symfony/phpunit-bridge": "^6.3|^7.0"
     },
     "minimum-stability": "dev",
     "autoload": {
@@ -34,5 +33,19 @@
         "psr-4": {
             "Symfonycasts\\SassBundle\\Tests\\": "tests/"
         }
+    },
+    "scripts": {
+        "tools:upgrade": [
+            "@tools:upgrade:php-cs-fixer",
+            "@tools:upgrade:phpstan"
+        ],
+        "tools:upgrade:php-cs-fixer": "composer upgrade -W -d tools/php-cs-fixer",
+        "tools:upgrade:phpstan": "composer upgrade -W -d tools/phpstan",
+        "tools:run": [
+            "@tools:run:php-cs-fixer",
+            "@tools:run:phpstan"
+        ],
+        "tools:run:php-cs-fixer": "tools/php-cs-fixer/vendor/bin/php-cs-fixer fix",
+        "tools:run:phpstan": "tools/phpstan/vendor/bin/phpstan --memory-limit=1G"
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-        - vendor/phpstan/phpstan-symfony/extension.neon
+        - tools/phpstan/vendor/phpstan/phpstan-symfony/extension.neon
 
 parameters:
     level: 5

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,2 @@
+**/vendor
+**/composer.lock

--- a/tools/php-cs-fixer/composer.json
+++ b/tools/php-cs-fixer/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "friendsofphp/php-cs-fixer": "^3"
+    }
+}

--- a/tools/phpstan/composer.json
+++ b/tools/phpstan/composer.json
@@ -1,0 +1,6 @@
+{
+    "require": {
+        "phpstan/phpstan": "^1",
+        "phpstan/phpstan-symfony": "^1.4"
+    }
+}


### PR DESCRIPTION
- `composer tools:run` runs `php-cs-fixer` & `phpstan`
- `composer tools:run:php-cs-fixer` run only `php-cs-fixer` (works for `phpstan` as well).
- `composer tools:upgrade` upgrades / installs all of the `tools/*`
- `composer tools:upgrade:php-cs-fixer` Upgrades / installs only `php-cs-fixer` (works for `phpstan` as well)