### PR TITLE
fix #75: detect `sass` binary in the path and use it if available

### DIFF
--- a/src/SassBuilder.php
+++ b/src/SassBuilder.php
@@ -10,6 +10,7 @@
 namespace Symfonycasts\SassBundle;
 
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\InputStream;
 use Symfony\Component\Process\Process;
 
@@ -182,7 +183,9 @@ class SassBuilder
 
     private function createBinary(): SassBinary
     {
-        return new SassBinary($this->projectRootDir.'/var', $this->binaryPath, $this->output);
+        $binaryPath = $this->binaryPath ?? (new ExecutableFinder())->find('sass');
+
+        return new SassBinary($this->projectRootDir.'/var', $binaryPath, $this->output);
     }
 
     /**


### PR DESCRIPTION
This PR fix #75 by doing:

- Use the binary `sass` if it is available in the path
- If the path is not available in the path, it will try to download it