### PR TITLE
feat: Option to search sass executable

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -20,6 +20,7 @@ return static function (ContainerConfigurator $container) {
                 param('kernel.project_dir'),
                 abstract_arg('path to binary'),
                 abstract_arg('sass options'),
+                abstract_arg('search binary'),
             ])
 
         ->set('sass.command.build', SassBuildCommand::class)

--- a/src/DependencyInjection/SymfonycastsSassExtension.php
+++ b/src/DependencyInjection/SymfonycastsSassExtension.php
@@ -37,6 +37,7 @@ class SymfonycastsSassExtension extends Extension implements ConfigurationInterf
             ->replaceArgument(1, '%kernel.project_dir%/var/sass')
             ->replaceArgument(3, $config['binary'])
             ->replaceArgument(4, $config['sass_options'])
+            ->replaceArgument(5, $config['search_binary'])
         ;
 
         $container->findDefinition('sass.css_asset_compiler')
@@ -86,6 +87,10 @@ class SymfonycastsSassExtension extends Extension implements ConfigurationInterf
                 ->scalarNode('binary')
                     ->info('The Sass binary to use')
                     ->defaultNull()
+                ->end()
+                ->scalarNode('search_binary')
+                    ->info('Whether to search for the Sass binary in the system PATH')
+                    ->defaultValue(true)
                 ->end()
                 ->arrayNode('sass_options')
                     ->addDefaultsIfNotSet()

--- a/src/DependencyInjection/SymfonycastsSassExtension.php
+++ b/src/DependencyInjection/SymfonycastsSassExtension.php
@@ -36,8 +36,8 @@ class SymfonycastsSassExtension extends Extension implements ConfigurationInterf
             ->replaceArgument(0, $config['root_sass'])
             ->replaceArgument(1, '%kernel.project_dir%/var/sass')
             ->replaceArgument(3, $config['binary'])
-            ->replaceArgument(4, $config['sass_options'])
-            ->replaceArgument(5, $config['search_for_binary'])
+            ->replaceArgument(4, $config['search_for_binary'])
+            ->replaceArgument(5, $config['sass_options'])
         ;
 
         $container->findDefinition('sass.css_asset_compiler')

--- a/src/DependencyInjection/SymfonycastsSassExtension.php
+++ b/src/DependencyInjection/SymfonycastsSassExtension.php
@@ -37,7 +37,7 @@ class SymfonycastsSassExtension extends Extension implements ConfigurationInterf
             ->replaceArgument(1, '%kernel.project_dir%/var/sass')
             ->replaceArgument(3, $config['binary'])
             ->replaceArgument(4, $config['sass_options'])
-            ->replaceArgument(5, $config['search_binary'])
+            ->replaceArgument(5, $config['search_for_binary'])
         ;
 
         $container->findDefinition('sass.css_asset_compiler')
@@ -88,7 +88,7 @@ class SymfonycastsSassExtension extends Extension implements ConfigurationInterf
                     ->info('The Sass binary to use')
                     ->defaultNull()
                 ->end()
-                ->scalarNode('search_binary')
+                ->scalarNode('search_for_binary')
                     ->info('Whether to search for the Sass binary in the system PATH')
                     ->defaultValue(true)
                 ->end()

--- a/src/SassBuilder.php
+++ b/src/SassBuilder.php
@@ -56,6 +56,7 @@ class SassBuilder
         private readonly string $projectRootDir,
         private readonly ?string $binaryPath,
         bool|array $sassOptions = [],
+        private readonly bool $searchBinary = true,
     ) {
         if (\is_bool($sassOptions)) {
             // Until 0.4, the $sassOptions argument was a boolean named $embedSourceMap
@@ -183,7 +184,11 @@ class SassBuilder
 
     private function createBinary(): SassBinary
     {
-        $binaryPath = $this->binaryPath ?? (new ExecutableFinder())->find('sass');
+        $binaryPath = $this->binaryPath;
+
+        if (null === $binaryPath && $this->searchBinary) {
+            $binaryPath = (new ExecutableFinder())->find('sass');
+        }
 
         return new SassBinary($this->projectRootDir.'/var', $binaryPath, $this->output);
     }

--- a/src/SassBuilder.php
+++ b/src/SassBuilder.php
@@ -55,7 +55,7 @@ class SassBuilder
         private readonly string $cssPath,
         private readonly string $projectRootDir,
         private readonly ?string $binaryPath,
-        private readonly bool $searchBinary,
+        private readonly bool $searchForBinary,
         bool|array $sassOptions = [],
     ) {
         if (\is_bool($sassOptions)) {
@@ -186,7 +186,7 @@ class SassBuilder
     {
         $binaryPath = $this->binaryPath;
 
-        if (null === $binaryPath && $this->searchBinary) {
+        if (null === $binaryPath && $this->searchForBinary) {
             $binaryPath = (new ExecutableFinder())->find('sass');
         }
 

--- a/src/SassBuilder.php
+++ b/src/SassBuilder.php
@@ -56,7 +56,7 @@ class SassBuilder
         private readonly string $projectRootDir,
         private readonly ?string $binaryPath,
         bool|array $sassOptions = [],
-        private readonly bool $searchBinary = true,
+        private readonly bool $searchBinary,
     ) {
         if (\is_bool($sassOptions)) {
             // Until 0.4, the $sassOptions argument was a boolean named $embedSourceMap

--- a/src/SassBuilder.php
+++ b/src/SassBuilder.php
@@ -55,8 +55,8 @@ class SassBuilder
         private readonly string $cssPath,
         private readonly string $projectRootDir,
         private readonly ?string $binaryPath,
-        bool|array $sassOptions = [],
         private readonly bool $searchBinary,
+        bool|array $sassOptions = [],
     ) {
         if (\is_bool($sassOptions)) {
             // Until 0.4, the $sassOptions argument was a boolean named $embedSourceMap

--- a/tests/SassBuilderTest.php
+++ b/tests/SassBuilderTest.php
@@ -38,6 +38,7 @@ class SassBuilderTest extends TestCase
             __DIR__.'/fixtures/assets',
             __DIR__.'/fixtures',
             null,
+            false,
         );
 
         $process = $builder->runBuild(false);
@@ -55,6 +56,7 @@ class SassBuilderTest extends TestCase
             __DIR__.'/fixtures/assets',
             __DIR__.'/fixtures',
             null,
+            false,
         );
 
         $process = $builder->runBuild(false);
@@ -78,6 +80,7 @@ class SassBuilderTest extends TestCase
             __DIR__.'/fixtures/assets',
             __DIR__.'/fixtures',
             null,
+            false,
             [
                 'embed_sources' => true,
                 'embed_source_map' => true,
@@ -120,6 +123,7 @@ class SassBuilderTest extends TestCase
             __DIR__.'/fixtures/assets',
             __DIR__.'/fixtures',
             null,
+            false,
             [
                 'style' => 'compressed',
                 'source_map' => false,
@@ -149,6 +153,7 @@ class SassBuilderTest extends TestCase
             __DIR__.'/fixtures/assets',
             __DIR__.'/fixtures',
             null,
+            false,
             $phpOptions,
         );
 
@@ -184,13 +189,32 @@ class SassBuilderTest extends TestCase
         $this->assertStringContainsString('WARNING', $process->getErrorOutput());
     }
 
+    public function testSearchForBinary(): void
+    {
+        $builder = new SassBuilder(
+            [__DIR__.'/fixtures/assets/app.scss'],
+            __DIR__.'/fixtures/assets',
+            __DIR__.'/fixtures',
+            null,
+            true,
+        );
+
+        $process = $builder->runBuild(false);
+        $process->wait();
+
+        $this->assertTrue($process->isSuccessful());
+        $this->assertFileExists(__DIR__.'/fixtures/assets/app.output.css');
+        $this->assertStringContainsString('color: red;', file_get_contents(__DIR__.'/fixtures/assets/app.output.css'));
+    }
+
     private function createBuilder(array|string $sassFiles, array $options = []): SassBuilder
     {
         return new SassBuilder(
-            array_map(fn (string $file): string => __DIR__.'/fixtures/assets/'.$file, (array) $sassFiles),
+            array_map(static fn (string $file): string => __DIR__.'/fixtures/assets/'.$file, (array) $sassFiles),
             __DIR__.'/fixtures/assets/dist',
             __DIR__.'/fixtures',
             null,
+            false,
             $options,
         );
     }


### PR DESCRIPTION
I recently encountered this issue (see #84) during a deployment to a cloud environment. Since this specific environment restricts the installation of external binaries, I suggest adding a configuration option that allows the bundle to automatically download the appropriate binary during cloud build phase.